### PR TITLE
Fixes: "invalid config: secret store not configured" error

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,14 +32,14 @@ impl TryInto<Config> for Vec<String> {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Export {
     pub local_addr: String,
     pub service_name: Option<String>,
     pub remote_ports: Vec<u16>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Import {
     pub remote_addr: String,
     pub local_addr: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,9 @@ impl OnionPipeBuilder {
     }
 
     pub fn config(mut self, cfg: config::Config) -> Result<OnionPipeBuilder> {
+        if let Some(secrets_dir) = cfg.secrets_dir {
+            self = self.secrets_dir(&secrets_dir);
+        }
         for cfg_export in cfg.exports {
             let export = match (cfg_export, self.secret_store.as_mut()).try_into() {
                 Ok(item) => item,


### PR DESCRIPTION
These changes were needed in order to get this to work:

```rust
// Create the SecretStore
    let mut secret_store = SecretStore::new(secrets_dir.to_str().unwrap());

    // Optional: Ensure a service key (generates if missing)
    secret_store.ensure_service("fuzzr2")?;

    let export_config = config::Export {
        local_addr: "127.0.0.1:6102".to_string(),
        service_name: Some("fuzzr2".to_string()),
        remote_ports: vec![80],
    };

    let export: Export = (export_config.clone(), Some(&mut secret_store)).try_into()?;

    let onion_address = export.remote_key.public().get_onion_address();
    println!("Onion address: {onion_address}");

    // Create the config
    let config = config::Config {
        temp_dir: Some("/tmp/fuzzr2".to_string()),
        secrets_dir: Some(secrets_dir.to_str().unwrap().to_string()),
        exports: vec![export_config],
        imports: vec![],
    };

    // Build the OnionPipe using OnionPipe::defaults() which returns OnionPipeBuilder
    let mut onion_pipe = OnionPipe::defaults().config(config)?.new().await?;

    // Run the onion pipe
    onion_pipe.run().await?;
```

Hope this is helpful!